### PR TITLE
Update README.md  lazy.nvim example to make work

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ If using Lazy.nvim
 return {
   {
     "theHamsta/nvim_rocks",
-    event = "VeryLazy",
     build = "pip3 install --user hererocks && python3 -mhererocks . -j2.1.0-beta3 -r3.0.0 && cp nvim_rocks.lua lua",
     config = function()
       ---- Add here the packages you want to make sure that they are installed


### PR DESCRIPTION
Removed lazy load (`event = "VeryLazy"`) from lazy.nvim example as this can stop any Lua code from finding the installed packages via `require()`.